### PR TITLE
Update set-output to use env file

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::$(python setup.py --version)
+      run: echo "VERSION=$(python setup.py --version)" >> $GITHUB_OUTPUT
 
     - name: Build documentation
       shell: bash -l {0}


### PR DESCRIPTION
`set-output` is now deprecated in Github Actions. Now the recommended method is to write to an environment file.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/