### PR TITLE
Fail on mamba failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,13 +26,13 @@ jobs:
 
     - name: Python ${{ matrix.python-version }}
       shell: bash -l {0}
-      run: |
+      run: >
         micromamba create --name TEST python=${{ matrix.python-version }} --file requirements.txt --file requirements-dev.txt --channel conda-forge
-        micromamba activate TEST
-        python -m pip install -e . --no-deps --force-reinstall
+        && micromamba activate TEST
+        && python -m pip install -e . --no-deps --force-reinstall
 
     - name: Tests
       shell: bash -l {0}
-      run: |
+      run: >
         micromamba activate TEST
-        python -m pytest -n 2 -rxs --cov=ioos_pkg_skeleton tests
+        && python -m pytest -n 2 -rxs --cov=ioos_pkg_skeleton tests


### PR DESCRIPTION
Currently if micromamba fails to build the environment it can still sometimes succeed at the step as the pip install can pass. This forces all the sub-steps in the run commands to need to pass.